### PR TITLE
fix: issue with "main" package prop pointing to wrong path

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "LICENSE",
     "lib"
   ],
-  "main": "src/index.js",
+  "main": "lib/index.js",
   "dependencies": {
     "rss": "^1.2.2"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 const test = require("tap").test
 
 const Metalsmith = require("metalsmith")
-const rss = require("../lib")
+const rss = require("../")
 
 test("metalsmith-rss", t => {
   new Metalsmith(__dirname)


### PR DESCRIPTION
Hello, just gave Metalsmith a try this weekend and found that after installing and loading this package I get `MODULE_NOT_FOUND` error:
 
![area_2022-April-04-Monday-11 05 23-blur](https://user-images.githubusercontent.com/5057797/161512036-f4cf748a-cda2-465d-bfc2-1db6ee79731d.png)

Looking at the source code I noticed the `main` property in `package.json` is pointing to the wrong path.