### PR TITLE
error message is never shown if collection name is invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,13 @@ Limit of items to put in the rss feed
 
 RSS encoding
 
-### `destination` (default: `"rss.xml"`)
+#### `destination` (default: `"rss.xml"`)
 
 Destination of the rss feed
+
+#### `pathProperty` (default: `"url"`)
+
+The name of the metadata property describing the relative path of the collection item.
 
 ## [Changelog](CHANGELOG.md)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,13 @@
 const RSS = require('rss')
 
 module.exports = (options = {}) => {
-  const { feedOptions, limit, encoding, destination, collection } = {
+  const { feedOptions, limit, encoding, destination, collection, pathProperty } = {
     feedOptions: {},
     limit: 20,
     encoding: 'utf8',
     destination: 'rss.xml',
     collection: 'posts',
+    pathProperty: 'url',
     ...options
   }
 
@@ -40,7 +41,7 @@ module.exports = (options = {}) => {
       feed.item({
         description: item.contents,
         ...item,
-        url: item.url ? new URL(item.url, feedOptions.site_url).toString() : undefined
+        url: item[pathProperty] ? new URL(item[pathProperty], feedOptions.site_url).toString() : undefined
       })
     })
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,7 @@ module.exports = (options = {}) => {
       return done(new Error('no collections configured - see metalsmith-collections'))
     }
 
-    if (!metadata.collections[collection].length) {
+    if (!metadata.collections[collection]?.length) {
       return done(new Error(`no item in collections '${collection}' - see metalsmith-collections`))
     }
 


### PR DESCRIPTION
If the collection name doesn't match a valid collection, the code returns 'TypeError: Cannot read properties of undefined (reading 'length')', which is not desired. The helpful error message is never shown.